### PR TITLE
Auto shutdown is now added to all virtual machines

### DIFF
--- a/solutions/README.md
+++ b/solutions/README.md
@@ -135,9 +135,9 @@ _PowerShell_
 
 ```powershell
 New-AzureRmResourceGroup -Name "automate-cluster" -Location "westeurope"
-New-AzureRmResourceGroupDeployment -TemplateUri https://raw.githubusercontent.com/chef-partners/arm-templates/automate/solutions/automatecluster.json `
+New-AzureRmResourceGroupDeployment -TemplateUri https://raw.githubusercontent.com/chef-partners/arm-templates/master/solutions/automatecluster.json `
 -TemplateParameterFile automatecluster.parameters.local.json `
--ResourceGroupName "automate-cluster"
+-ResourceGroupName "automate-cluster" `
 -Name "automate-deploy-1"
 ```
 

--- a/solutions/automatecluster-infranodes.json
+++ b/solutions/automatecluster-infranodes.json
@@ -49,8 +49,8 @@
         "description": "Object stating the size of the machines that are to be created in this cluster"
       },
       "defaultValue": {
-        "orchestration": "Standard_D1_V2",
-        "buildnode": "Standard_D1_V2",
+        "orchestration": "Standard_DS1_V2",
+        "buildnode": "Standard_DS1_V2",
         "chefserver": "Standard_DS2_V2",
         "automateserver": "Standard_DS2_V2",
         "complianceserver": "Standard_DS2_V2",
@@ -255,6 +255,29 @@
         "clientSecret": "",
         "tenantId": ""
       }
+    },
+
+    "autoShutdown": {
+      "type": "object",
+      "metadata": {
+        "description": "Object specifying if Auto shutdown should be configured"
+      },
+      "defaultValue": {
+
+        "shutdown": {
+          "status": "Disabled",
+          "timezone": "UTC",
+          "time": "1900"
+        }
+      }
+    },
+
+    "unique": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique string to use for the storage account.  If not set it will be generated."
+      },
+      "defaultValue": "[uniqueString(subscription().subscriptionId, resourceGroup().id, deployment().name, parameters('prefix'))]"
     }
   },
 
@@ -393,6 +416,14 @@
 
             "spnDetails": {
               "value": "[parameters('spnDetails')]"
+            },
+
+            "unique": {
+              "value": "[parameters('unique')]"
+            },
+
+            "autoShutdown": {
+              "value": "[parameters('autoShutdown')]"
             }
         }
       }
@@ -461,6 +492,9 @@
               },
               "runlist": "[parameters('infrastructureNodes').runlist]"
             }
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
           }
         }
       }

--- a/solutions/automatecluster.json
+++ b/solutions/automatecluster.json
@@ -239,11 +239,34 @@
         "clientSecret": "",
         "tenantId": ""
       }
+    },
+
+    "autoShutdown": {
+      "type": "object",
+      "metadata": {
+        "description": "Object specifying if Auto shutdown should be configured"
+      },
+      "defaultValue": {
+
+        "shutdown": {
+          "status": "Disabled",
+          "timezone": "UTC",
+          "time": "1900"
+        }
+      }
+    },
+
+    "unique": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique string to use for the storage account.  If not set it will be generated."
+      },
+      "defaultValue": "[uniqueString(subscription().subscriptionId, resourceGroup().id, deployment().name, parameters('prefix'))]"
     }
   },
   "variables": {
 
-    "unique": "[uniqueString(subscription().subscriptionId, resourceGroup().id, deployment().name, parameters('prefix'))]",
+    "unique": "[parameters('unique')]",
     "uniqueShort": "[substring(variables('unique'), 0, parameters('shortUniqueLength'))]",
     "location": "[resourceGroup().location]",
 
@@ -454,6 +477,9 @@
           },
           "ipAddress": {
             "value": "[parameters('ipAddresses').orchestration]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
           }
         }
       }
@@ -509,6 +535,9 @@
           },
           "omsAttributes": {
             "value": "[variables('oms')]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
           }
         }
       }
@@ -560,6 +589,9 @@
           },
           "omsAttributes": {
             "value": "[variables('oms')]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
           }
         }
       }
@@ -618,6 +650,9 @@
           },
           "omsAttributes": {
             "value": "[variables('oms')]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
           }
         }
       }
@@ -669,6 +704,9 @@
           },
           "omsAttributes": {
             "value": "[variables('oms')]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
           }
         }
       }
@@ -730,6 +768,15 @@
           },
           "spnDetails": {
             "value": "[parameters('spnDetails')]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
+          },
+          "automateServerFQDN": {
+            "value": "[reference('Microsoft.Resources/deployments/AutomateCluster-AutomateServer').outputs.fqdn.value]"
+          },
+          "automateServerUrl": {
+            "value": "[reference('Microsoft.Resources/deployments/AutomateCluster-AutomateServer').outputs.url.value]"
           }
         }
       }

--- a/solutions/nested/auto-shutdown/auto-shutdown.json
+++ b/solutions/nested/auto-shutdown/auto-shutdown.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+
+      "vmName": {
+        "type": "string"
+      },
+
+      "autoShutdown": {
+        "type": "object"
+      }
+    },
+    "variables": {
+
+    },
+    "resources": [
+        {
+            "apiVersion": "2016-05-15",
+            "type": "Microsoft.DevTestLab/schedules",
+            "name": "[concat('shutdown-computevm-', parameters('vmName'))]",
+            "location": "[resourceGroup().location]",
+            "properties":
+            {
+                "status": "[parameters('autoShutdown').shutdown.status]",
+                "timeZoneId": "[parameters('autoShutdown').shutdown.timezone]",
+                "taskType": "ComputeVmShutdownTask",
+                "notificationSettings":{
+                    "status": "Disabled",
+                    "timeInMinutes": 15,
+                    "webhookUrl": null
+                },
+                "targetResourceId": "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]",
+                "dailyRecurrence":{
+                    "time": "[parameters('autoShutdown').shutdown.time]"
+                }
+            }
+        }
+    ],
+    "outputs": {
+      
+    }
+}

--- a/solutions/nested/scripts/azurecred.ps1
+++ b/solutions/nested/scripts/azurecred.ps1
@@ -74,7 +74,7 @@ $secpasswd = ConvertTo-SecureString $subscriptionPassword -AsPlainText -Force
 $creds = New-Object System.Management.Automation.PSCredential ($subscriptionUsername, $secpasswd)
 
 # Login to Azure
-Add-AzureRMAccount -Credential $creds -SubscriptionId $subscriptionId
+Add-AzureRMAccount -Credential $creds # -SubscriptionId $subscriptionId
 
 try
 {

--- a/solutions/nested/scripts/windows-workstation.ps1
+++ b/solutions/nested/scripts/windows-workstation.ps1
@@ -66,7 +66,13 @@ param (
 
   [string]
   # tenant id
-  $tenantId
+  $tenantId,
+
+  [string]
+  $automateServerFQDN,
+
+  [string]
+  $automateServerUrl
 
 )
 
@@ -238,6 +244,10 @@ foreach ($mode in $modes) {
             default = @{
               home = $homedir
             }
+          }
+          automate = @{
+            fqdn = $automateServerFQDN
+            url = $automateServerUrl
           }
         }
         azure = @{

--- a/solutions/nested/security-groups/windows-workstation.json
+++ b/solutions/nested/security-groups/windows-workstation.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "groupName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the security group"
+      },
+      "defaultValue": "ChefServers-NSG"
+    },
+    "location": {
+      "type": "string"
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "apiVersion": "2016-03-30",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[parameters('groupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "RDP-3389",
+            "properties": {
+              "description": "Allow RDP port 3389 traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "80",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "VirtualNetwork",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "nsgId": {
+      "value": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('groupName'))]",
+      "type": "string"
+    },
+    "groupName": {
+      "type": "string",
+      "value": "[parameters('groupName')]"
+    }
+  }
+}

--- a/solutions/nested/wrappers/vm-buildnode.json
+++ b/solutions/nested/wrappers/vm-buildnode.json
@@ -92,6 +92,21 @@
       "metadata": {
         "description": "Object detailing the workspace id and key to configure OMS on the machine"
       }
+    },
+    
+    "autoShutdown": {
+      "type": "object",
+      "metadata": {
+        "description": "Object specifying if Auto shutdown should be configured"
+      },
+      "defaultValue": {
+
+        "shutdown": {
+          "status": "Disabled",
+          "timezone": "UTC",
+          "time": "1900"
+        }
+      }
     }
   },
 
@@ -133,6 +148,7 @@
       "networkInterface": "[uri(deployment().properties.templateLink.uri, '../network-interface/network-interface-static.json')]",
       "virtualMachine": "[uri(deployment().properties.templateLink.uri, concat('../virtual-machine/virtual-machine-', parameters('machinePlatform'), '.json'))]",
       "configurationScript": "[uri(deployment().properties.templateLink.uri, concat('../scripts/setup-ctl.sh'))]",
+      "autoShutdown": "[uri(deployment().properties.templateLink.uri, '../auto-shutdown/auto-shutdown.json')]",
       "extensions": {
         "oms": "[uri(deployment().properties.templateLink.uri, concat('../monitoring/omsagent-linux-', parameters('omsAttributes').enable, '.json'))]"
       }
@@ -238,6 +254,30 @@
             "nicRef": {
               "value": "[reference(concat(variables('name').nic, '-Deployment')).outputs.ref.value]"
             }
+        }
+      }
+    },
+
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(variables('name').vm, '-AutoShutdown-Deployment')]",
+      "apiVersion": "[variables('apiVersions').deployments]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('name').vm, '-Deployment')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('urls').autoShutdown]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vmName": {
+            "value": "[variables('name').vm]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
+          }
         }
       }
     },

--- a/solutions/nested/wrappers/vm-orchestration.json
+++ b/solutions/nested/wrappers/vm-orchestration.json
@@ -67,6 +67,21 @@
       "metadata": {
         "description": "Static IP address to set on the machine"
       }
+    },
+    
+    "autoShutdown": {
+      "type": "object",
+      "metadata": {
+        "description": "Object specifying if Auto shutdown should be configured"
+      },
+      "defaultValue": {
+
+        "shutdown": {
+          "status": "Disabled",
+          "timezone": "UTC",
+          "time": "1900"
+        }
+      }
     }
   },
 
@@ -111,7 +126,8 @@
       "networkInterface": "[uri(deployment().properties.templateLink.uri, '../network-interface/network-interface-static.json')]",
       "virtualMachine": "[uri(deployment().properties.templateLink.uri, concat('../virtual-machine/virtual-machine-ubuntu.json'))]",
       "dockerExtension": "[uri(deployment().properties.templateLink.uri, concat('../extensions/docker-extension.json'))]",
-      "configurationScript": "[uri(deployment().properties.templateLink.uri, concat('../scripts/setup-ctl.sh'))]"
+      "configurationScript": "[uri(deployment().properties.templateLink.uri, concat('../scripts/setup-ctl.sh'))]",
+      "autoShutdown": "[uri(deployment().properties.templateLink.uri, '../auto-shutdown/auto-shutdown.json')]"
     },
 
     "apiVersions": {
@@ -193,6 +209,30 @@
 
     {
       "type": "Microsoft.Resources/deployments",
+      "name": "[concat(variables('name').vm, '-AutoShutdown-Deployment')]",
+      "apiVersion": "[variables('apiVersions').deployments]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('name').vm, '-Deployment')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('urls').autoShutdown]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vmName": {
+            "value": "[variables('name').vm]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
+          }
+        }
+      }
+    },
+
+    {
+      "type": "Microsoft.Resources/deployments",
       "name": "[concat(variables('name').extension.docker, '-Deployment')]",
       "apiVersion": "[variables('apiVersions').deployments]",
       "dependsOn": [
@@ -234,7 +274,7 @@
           "fileUris": [
             "[variables('urls').configurationScript]"
           ],
-          "commandToExecute": "[concat('./setup-ctl.sh -m orchestration')]"
+          "commandToExecute": "[concat('./setup-ctl.sh -m orchestration --location ', resourceGroup().location)]"
         }
       },
       "location": "[resourceGroup().location]"

--- a/solutions/nested/wrappers/vm-publicip-automateserver-scratch.json
+++ b/solutions/nested/wrappers/vm-publicip-automateserver-scratch.json
@@ -99,6 +99,21 @@
       "metadata": {
         "description": "Object detailing the workspace id and key to configure OMS on the machine"
       }
+    },
+    
+    "autoShutdown": {
+      "type": "object",
+      "metadata": {
+        "description": "Object specifying if Auto shutdown should be configured"
+      },
+      "defaultValue": {
+
+        "shutdown": {
+          "status": "Disabled",
+          "timezone": "UTC",
+          "time": "1900"
+        }
+      }
     }
   },
 
@@ -140,6 +155,7 @@
       "networkInterface": "[uri(deployment().properties.templateLink.uri, '../network-interface/network-interface-static-publicip.json')]",
       "virtualMachine": "[uri(deployment().properties.templateLink.uri, concat('../virtual-machine/virtual-machine-ubuntu.json'))]",
       "configurationScript": "[uri(deployment().properties.templateLink.uri, concat('../scripts/setup-ctl.sh'))]",
+      "autoShutdown": "[uri(deployment().properties.templateLink.uri, '../auto-shutdown/auto-shutdown.json')]",
       "extensions": {
         "oms": "[uri(deployment().properties.templateLink.uri, concat('../monitoring/omsagent-linux-', parameters('omsAttributes').enable, '.json'))]"
       }
@@ -256,6 +272,30 @@
             "fqdn": {
               "value": "[reference(concat(variables('name').publicIPAddress, '-Deployment')).outputs.fqdn.value]"
             }
+        }
+      }
+    },
+
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(variables('name').vm, '-AutoShutdown-Deployment')]",
+      "apiVersion": "[variables('apiVersions').deployments]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('name').vm, '-Deployment')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('urls').autoShutdown]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vmName": {
+            "value": "[variables('name').vm]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
+          }
         }
       }
     },

--- a/solutions/nested/wrappers/vm-publicip-buildnode.json
+++ b/solutions/nested/wrappers/vm-publicip-buildnode.json
@@ -78,6 +78,21 @@
       "metadata": {
         "description": "Internal IP address of the orchestration server from which data can be retrieved"
       }
+    },
+    
+    "autoShutdown": {
+      "type": "object",
+      "metadata": {
+        "description": "Object specifying if Auto shutdown should be configured"
+      },
+      "defaultValue": {
+
+        "shutdown": {
+          "status": "Disabled",
+          "timezone": "UTC",
+          "time": "1900"
+        }
+      }
     }
   },
 
@@ -118,6 +133,7 @@
       "publicIPAddress": "[uri(deployment().properties.templateLink.uri, '../public-ipaddress/public-ipaddress.json')]",
       "networkInterface": "[uri(deployment().properties.templateLink.uri, '../network-interface/network-interface-publicip.json')]",
       "virtualMachine": "[uri(deployment().properties.templateLink.uri, concat('../virtual-machine/virtual-machine-', parameters('machinePlatform'), '.json'))]",
+      "autoShutdown": "[uri(deployment().properties.templateLink.uri, '../auto-shutdown/auto-shutdown.json')]",
       "configurationScript": "[uri(deployment().properties.templateLink.uri, concat('../scripts/setup-ctl.sh'))]"
     },
 
@@ -221,6 +237,30 @@
             "nicRef": {
               "value": "[reference(concat(variables('name').nic, '-Deployment')).outputs.ref.value]"
             }
+        }
+      }
+    },
+
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(variables('name').vm, '-AutoShutdown-Deployment')]",
+      "apiVersion": "[variables('apiVersions').deployments]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('name').vm, '-Deployment')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('urls').autoShutdown]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vmName": {
+            "value": "[variables('name').vm]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
+          }
         }
       }
     },

--- a/solutions/nested/wrappers/vm-publicip-chef.json
+++ b/solutions/nested/wrappers/vm-publicip-chef.json
@@ -85,6 +85,21 @@
     "NSGRef": {
       "type": "string",
       "defaultValue": ""
+    },
+    
+    "autoShutdown": {
+      "type": "object",
+      "metadata": {
+        "description": "Object specifying if Auto shutdown should be configured"
+      },
+      "defaultValue": {
+
+        "shutdown": {
+          "status": "Disabled",
+          "timezone": "UTC",
+          "time": "1900"
+        }
+      }
     }
   },
 
@@ -126,6 +141,7 @@
       "publicIPAddress": "[uri(deployment().properties.templateLink.uri, '../public-ipaddress/public-ipaddress.json')]",
       "networkInterface": "[uri(deployment().properties.templateLink.uri, '../network-interface/network-interface-publicip.json')]",
       "virtualMachine": "[uri(deployment().properties.templateLink.uri, concat('../virtual-machine/virtual-machine-', parameters('machinePlatform'), '.json'))]",
+      "autoShutdown": "[uri(deployment().properties.templateLink.uri, '../auto-shutdown/auto-shutdown.json')]",
       "chefExtension": "[uri(deployment().properties.templateLink.uri, concat('../extensions/chef-extension-', parameters('machinePlatform'), '.json'))]"
     },
 
@@ -235,6 +251,30 @@
             "nicRef": {
               "value": "[reference(concat(variables('name').nic, '-Deployment')).outputs.ref.value]"
             }
+        }
+      }
+    },
+
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(variables('name').vm, '-AutoShutdown-Deployment')]",
+      "apiVersion": "[variables('apiVersions').deployments]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('name').vm, '-Deployment')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('urls').autoShutdown]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vmName": {
+            "value": "[variables('name').vm]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
+          }
         }
       }
     },

--- a/solutions/nested/wrappers/vm-publicip-chefserver-scratch.json
+++ b/solutions/nested/wrappers/vm-publicip-chefserver-scratch.json
@@ -90,6 +90,21 @@
         "description": "Object detailing the workspace id and key to configure OMS on the machine"
       },
       "defaultValue": {}
+    },
+    
+    "autoShutdown": {
+      "type": "object",
+      "metadata": {
+        "description": "Object specifying if Auto shutdown should be configured"
+      },
+      "defaultValue": {
+
+        "shutdown": {
+          "status": "Disabled",
+          "timezone": "UTC",
+          "time": "1900"
+        }
+      }
     }
   },
 
@@ -131,6 +146,7 @@
       "networkInterface": "[uri(deployment().properties.templateLink.uri, '../network-interface/network-interface-static-publicip.json')]",
       "virtualMachine": "[uri(deployment().properties.templateLink.uri, concat('../virtual-machine/virtual-machine-ubuntu.json'))]",
       "configurationScript": "[uri(deployment().properties.templateLink.uri, concat('../scripts/setup-ctl.sh'))]",
+      "autoShutdown": "[uri(deployment().properties.templateLink.uri, '../auto-shutdown/auto-shutdown.json')]",
       "extensions": {
         "oms": "[uri(deployment().properties.templateLink.uri, concat('../monitoring/omsagent-linux-', parameters('omsAttributes').enable, '.json'))]"
       }
@@ -247,6 +263,30 @@
             "fqdn": {
               "value": "[reference(concat(variables('name').publicIPAddress, '-Deployment')).outputs.fqdn.value]"
             }
+        }
+      }
+    },
+
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(variables('name').vm, '-AutoShutdown-Deployment')]",
+      "apiVersion": "[variables('apiVersions').deployments]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('name').vm, '-Deployment')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('urls').autoShutdown]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vmName": {
+            "value": "[variables('name').vm]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
+          }
         }
       }
     },

--- a/solutions/nested/wrappers/vm-publicip-complianceserver-scratch.json
+++ b/solutions/nested/wrappers/vm-publicip-complianceserver-scratch.json
@@ -88,6 +88,21 @@
       "metadata": {
         "description": "Object detailing the workspace id and key to configure OMS on the machine"
       }
+    },
+    
+    "autoShutdown": {
+      "type": "object",
+      "metadata": {
+        "description": "Object specifying if Auto shutdown should be configured"
+      },
+      "defaultValue": {
+
+        "shutdown": {
+          "status": "Disabled",
+          "timezone": "UTC",
+          "time": "1900"
+        }
+      }
     }
   },
 
@@ -129,6 +144,7 @@
       "networkInterface": "[uri(deployment().properties.templateLink.uri, '../network-interface/network-interface-static-publicip.json')]",
       "virtualMachine": "[uri(deployment().properties.templateLink.uri, concat('../virtual-machine/virtual-machine-ubuntu.json'))]",
       "configurationScript": "[uri(deployment().properties.templateLink.uri, concat('../scripts/setup-ctl.sh'))]",
+      "autoShutdown": "[uri(deployment().properties.templateLink.uri, '../auto-shutdown/auto-shutdown.json')]",
       "extensions": {
         "oms": "[uri(deployment().properties.templateLink.uri, concat('../monitoring/omsagent-linux-', parameters('omsAttributes').enable, '.json'))]"
       }
@@ -245,6 +261,30 @@
             "fqdn": {
               "value": "[reference(concat(variables('name').publicIPAddress, '-Deployment')).outputs.fqdn.value]"
             }
+        }
+      }
+    },
+
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(variables('name').vm, '-AutoShutdown-Deployment')]",
+      "apiVersion": "[variables('apiVersions').deployments]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('name').vm, '-Deployment')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('urls').autoShutdown]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vmName": {
+            "value": "[variables('name').vm]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
+          }
         }
       }
     },

--- a/solutions/nested/wrappers/vm-publicip-infranode.json
+++ b/solutions/nested/wrappers/vm-publicip-infranode.json
@@ -85,6 +85,21 @@
     "NSGRef": {
       "type": "string",
       "defaultValue": ""
+    },
+    
+    "autoShutdown": {
+      "type": "object",
+      "metadata": {
+        "description": "Object specifying if Auto shutdown should be configured"
+      },
+      "defaultValue": {
+
+        "shutdown": {
+          "status": "Disabled",
+          "timezone": "UTC",
+          "time": "1900"
+        }
+      }
     }
   },
 
@@ -128,6 +143,7 @@
       "networkInterface": "[uri(deployment().properties.templateLink.uri, '../network-interface/network-interface-publicip.json')]",
       "virtualMachine": "[uri(deployment().properties.templateLink.uri, concat('../virtual-machine/virtual-machine-', parameters('machinePlatform'), '.json'))]",
       "chefExtension": "[uri(deployment().properties.templateLink.uri, concat('../extensions/chef-extension-', parameters('machinePlatform'), '.json'))]",
+      "autoShutdown": "[uri(deployment().properties.templateLink.uri, '../auto-shutdown/auto-shutdown.json')]",
       "configurationScriptExtension": "[uri(deployment().properties.templateLink.uri, concat('../extensions/script-extension-', parameters('machinePlatform'), '.json'))]"
     },
 
@@ -237,6 +253,30 @@
             "nicRef": {
               "value": "[reference(concat(variables('name').nic, '-Deployment')).outputs.ref.value]"
             }
+        }
+      }
+    },
+
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(variables('name').vm, '-AutoShutdown-Deployment')]",
+      "apiVersion": "[variables('apiVersions').deployments]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('name').vm, '-Deployment')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('urls').autoShutdown]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vmName": {
+            "value": "[variables('name').vm]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
+          }
         }
       }
     },

--- a/solutions/nested/wrappers/vm-publicip-windows-workstation.json
+++ b/solutions/nested/wrappers/vm-publicip-windows-workstation.json
@@ -126,6 +126,29 @@
         "clientSecret": "",
         "tenantId": ""
       }
+    },
+
+    "autoShutdown": {
+      "type": "object",
+      "metadata": {
+        "description": "Object specifying if Auto shutdown should be configured"
+      },
+      "defaultValue": {
+
+        "shutdown": {
+          "status": "Disabled",
+          "timezone": "UTC",
+          "time": "1900"
+        }
+      }
+    },
+
+    "automateServerFQDN": {
+      "type": "string"
+    },
+
+    "automateServerUrl": {
+      "type": "string"
     }
   },
 
@@ -166,6 +189,7 @@
     "urls": {
       "publicIPAddress": "[uri(deployment().properties.templateLink.uri, '../public-ipaddress/public-ipaddress.json')]",
       "networkInterface": "[uri(deployment().properties.templateLink.uri, '../network-interface/network-interface-publicip.json')]",
+      "autoShutdown": "[uri(deployment().properties.templateLink.uri, '../auto-shutdown/auto-shutdown.json')]",
       "virtualMachine": "[uri(deployment().properties.templateLink.uri, concat('../virtual-machine/virtual-machine-windows.json'))]",
         "configurationScript": "[uri(deployment().properties.templateLink.uri, concat('../scripts/windows-workstation.ps1'))]"
     },
@@ -286,6 +310,30 @@
       }
     },
 
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(variables('name').vm, '-AutoShutdown-Deployment')]",
+      "apiVersion": "[variables('apiVersions').deployments]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('name').vm, '-Deployment')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('urls').autoShutdown]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "vmName": {
+            "value": "[variables('name').vm]"
+          },
+          "autoShutdown": {
+            "value": "[parameters('autoShutdown')]"
+          }
+        }
+      }
+    },
+
     /*
     Add the Windows Custom script extension to configure the workstation
     */
@@ -306,7 +354,7 @@
               "fileUris": [
                   "[variables('urls').configurationScript]"
               ],
-              "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File .\\windows-workstation.ps1 -operation \"chefdk,chefrepo,chefclient\" -chefdk_version 1.0.3 -chef_repo_url \"', parameters('chefRepoUrl'), '\" -chef_org \"', parameters('chefOrg'), '\" -chef_server_url \"', parameters('chefServerUrl'), '\" -chef_user \"', parameters('chefUser'), '\" -windows_password \"', parameters('adminPassword'), '\" -subscriptionId \"', variables('subscription').id, '\" -subscriptionPassword \"', variables('subscription').password, '\" -subscriptionUsername \"', variables('subscription').username, '\" -azurelocation \"', variables('location'), '\" -clientId \"', parameters('spnDetails').clientId, '\" -clientSecret \"', parameters('spnDetails').clientSecret, '\" -tenantId \"', parameters('spnDetails').tenantId, '\" > windows-workstation.log')]"
+              "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File .\\windows-workstation.ps1 -operation \"chefdk,chefrepo,chefclient\" -chefdk_version 1.0.3 -chef_repo_url \"', parameters('chefRepoUrl'), '\" -chef_org \"', parameters('chefOrg'), '\" -chef_server_url \"', parameters('chefServerUrl'), '\" -chef_user \"', parameters('chefUser'), '\" -windows_password \"', parameters('adminPassword'), '\" -subscriptionId \"', variables('subscription').id, '\" -subscriptionPassword \"', variables('subscription').password, '\" -subscriptionUsername \"', variables('subscription').username, '\" -azurelocation \"', variables('location'), '\" -clientId \"', parameters('spnDetails').clientId, '\" -clientSecret \"', parameters('spnDetails').clientSecret, '\" -tenantId \"', parameters('spnDetails').tenantId, '\" -automateServerFQDN \"', parameters('automateServerFQDN'), '\" -automateServerUrl \"', parameters('automateServerUrl'), '\" > windows-workstation.log')]"
           }
       }
     }


### PR DESCRIPTION
Although the ability to auto shutdown machines has been added to all machines it is disabled by default.

The idea behind this is to be able to spin up a cluster or set of machines and get Azure to shut them down at a later time.  This is ideal when setting up workshops or classes in time limit or cost limited susbscriptions.

Closes #18 

Corrected issue with README file #19

