### PR TITLE
Support for Managed Disks

### DIFF
--- a/solutions/automate-workstation.json
+++ b/solutions/automate-workstation.json
@@ -114,32 +114,8 @@
 
     {
       "type": "Microsoft.Resources/deployments",
-      "name": "StorageAccountSetup",
-      "apiVersion": "[variables('apiVersions').deployments]",
-      "properties": {
-      "mode": "Incremental",
-        "templateLink": {
-          "uri": "[variables('urls').storageAccount]",
-          "contentVersion": "1.0.0.0"
-        },
-        "parameters": {
-          "location": {
-            "value": "[variables('location')]"
-          },
-          "storageAccountName": {
-            "value": "[variables('name').sa.name]"
-          }
-        }
-      }
-    },
-
-    {
-      "type": "Microsoft.Resources/deployments",
       "name": "AutomateWorkstation-Deployment",
       "apiVersion": "[variables('apiVersions').deployments]",
-      "dependsOn": [
-        "Microsoft.Resources/deployments/StorageAccountSetup"
-      ],
       "properties": {
         "mode": "Incremental",
         "templateLink": {

--- a/solutions/automatecluster.json
+++ b/solutions/automatecluster.json
@@ -363,30 +363,6 @@
 
     {
       "type": "Microsoft.Resources/deployments",
-      "name": "AutomateCluster-StorageAccount",
-      "apiVersion": "2016-02-01",
-      "properties": {
-          "mode": "Incremental",
-          "templateLink": {
-            "uri": "[variables('urls').storageAccount]",
-            "contentVersion": "1.0.0.0"
-          },
-          "parameters": {
-            "location": {
-              "value": "[variables('location')]"
-            },
-            "storageAccountType": {
-              "value": "[variables('storageAccountType')]"
-            },
-            "storageAccountName": {
-              "value": "[variables('name').storageAccountName]"
-            }
-          }
-      }
-    },
-
-    {
-      "type": "Microsoft.Resources/deployments",
       "name": "AutomateCluster-NSG",
       "apiVersion": "2016-02-01",
       "properties": {
@@ -444,7 +420,6 @@
       "name": "AutomateCluster-OrchestrationServer",
       "apiVersion": "2016-02-01",
       "dependsOn": [
-        "Microsoft.Resources/deployments/AutomateCluster-StorageAccount",
         "Microsoft.Resources/deployments/AutomateCluster-VirtualNetwork"
       ],
       "properties": {

--- a/solutions/chef-nodes-linux.json
+++ b/solutions/chef-nodes-linux.json
@@ -175,27 +175,6 @@
 
     {
       "type": "Microsoft.Resources/deployments",
-      "name": "StorageAccountSetup",
-      "apiVersion": "[variables('apiVersions').deployments]",
-      "properties": {
-      "mode": "Incremental",
-        "templateLink": {
-          "uri": "[variables('urls').storageAccount]",
-          "contentVersion": "1.0.0.0"
-        },
-        "parameters": {
-          "location": {
-            "value": "[variables('location')]"
-          },
-          "storageAccountName": {
-            "value": "[variables('name').sa.name]"
-          }
-        }
-      }
-    },
-
-    {
-      "type": "Microsoft.Resources/deployments",
       "name": "[concat(parameters('prefix'), '-', parameters('vmType'), '-', variables('uniqueShort'), '-', copyIndex(1), '-Deployment')]",
       "apiVersion": "[variables('apiVersions').deployments]",
       "copy": {

--- a/solutions/chef-nodes-windows.json
+++ b/solutions/chef-nodes-windows.json
@@ -174,27 +174,6 @@
 
     {
       "type": "Microsoft.Resources/deployments",
-      "name": "StorageAccountSetup",
-      "apiVersion": "[variables('apiVersions').deployments]",
-      "properties": {
-      "mode": "Incremental",
-        "templateLink": {
-          "uri": "[variables('urls').storageAccount]",
-          "contentVersion": "1.0.0.0"
-        },
-        "parameters": {
-          "location": {
-            "value": "[variables('location')]"
-          },
-          "storageAccountName": {
-            "value": "[variables('name').sa.name]"
-          }
-        }
-      }
-    },
-
-    {
-      "type": "Microsoft.Resources/deployments",
       "name": "[concat(parameters('prefix'), '-', parameters('vmType'), '-', variables('uniqueShort'), '-', copyIndex(1), '-Deployment')]",
       "apiVersion": "[variables('apiVersions').deployments]",
       "copy": {

--- a/solutions/nested/scripts/setup-ctl.sh
+++ b/solutions/nested/scripts/setup-ctl.sh
@@ -360,7 +360,7 @@ do
         echo "Checking Automate Server"
 
         # Determine the download path for the chef server
-        download_url=$(printf 'https://packages.chef.io/files/stable/automate/%s/ubuntu/16.04/delivery_%s-1_amd64.deb' $AUTOMATE_SERVER_VERSION)
+        download_url=$(printf 'https://packages.chef.io/files/stable/automate/%s/ubuntu/16.04/delivery_%s-1_amd64.deb' $AUTOMATE_SERVER_VERSION $AUTOMATE_SERVER_VERSION)
 
         install delivery-ctl $download_url 
       fi

--- a/solutions/nested/scripts/setup-ctl.sh
+++ b/solutions/nested/scripts/setup-ctl.sh
@@ -360,7 +360,7 @@ do
         echo "Checking Automate Server"
 
         # Determine the download path for the chef server
-        download_url=$(printf 'https://packages.chef.io/stable/ubuntu/16.04/delivery_%s-1_amd64.deb' $AUTOMATE_SERVER_VERSION)
+        download_url=$(printf 'https://packages.chef.io/files/stable/automate/%s/ubuntu/16.04/delivery_%s-1_amd64.deb' $AUTOMATE_SERVER_VERSION)
 
         install delivery-ctl $download_url 
       fi

--- a/solutions/nested/scripts/setup-ctl.sh
+++ b/solutions/nested/scripts/setup-ctl.sh
@@ -360,7 +360,7 @@ do
         echo "Checking Automate Server"
 
         # Determine the download path for the chef server
-        download_url=$(printf 'https://packages.chef.io/files/stable/automate/%s/ubuntu/16.04/delivery_%s-1_amd64.deb' $AUTOMATE_SERVER_VERSION $AUTOMATE_SERVER_VERSION)
+        download_url=$(printf 'https://packages.chef.io/files/stable/automate/%s/ubuntu/16.04/automate_%s-1_amd64.deb' $AUTOMATE_SERVER_VERSION $AUTOMATE_SERVER_VERSION)
 
         install delivery-ctl $download_url 
       fi

--- a/solutions/nested/virtual-machine/virtual-machine-ubuntu.json
+++ b/solutions/nested/virtual-machine/virtual-machine-ubuntu.json
@@ -137,7 +137,7 @@
     "vmSize": "[parameters('vmSize')]",
 
     "apiVersions": {
-      "virtualMachines": "2015-06-15"
+      "virtualMachines": "2016-04-30-preview"
     },
 
     "image": {
@@ -170,21 +170,15 @@
             "version": "latest"
           },
           "osDisk": {
-            "name": "osdisk",
-            "vhd": {
-              "uri": "[concat('http://', variables('name').sa.name,'.blob.core.windows.net/', variables('name').sa.containerName,'/',variables('name').disk.os,'.vhd')]"
-            },
-            "caching": "ReadWrite",
+            "name": "[variables('name').disk.os]",
+            "caching": "ReadOnly",
             "createOption": "FromImage"
           },
           "dataDisks": [
             {
-              "name": "datadisk1",
+              "name": "[variables('name').disk.data]",
               "diskSizeGB": "100",
               "lun": 0,
-              "vhd": {
-                "uri": "[concat('http://', variables('name').sa.name, '.blob.core.windows.net/' ,variables('name').sa.containerName,'/',variables('name').disk.data,'.vhd')]"
-              },
               "createOption": "Empty"
             }
           ]
@@ -198,8 +192,7 @@
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
-            "enabled": "false",
-            "storageUri": "[concat('http://', variables('name').sa.name, '.blob.core.windows.net')]"
+            "enabled": "false"
           }
         }
       }

--- a/solutions/nested/virtual-machine/virtual-machine-windows.json
+++ b/solutions/nested/virtual-machine/virtual-machine-windows.json
@@ -78,7 +78,7 @@
     "vmSize": "[parameters('vmSize')]",
 
     "apiVersions": {
-      "virtualMachines": "2015-06-15"
+      "virtualMachines": "2016-04-30-preview"
     },
 
     "image": {
@@ -115,21 +115,15 @@
             "version": "latest"
           },
           "osDisk": {
-            "name": "osdisk",
-            "vhd": {
-              "uri": "[concat('http://', variables('name').sa.name,'.blob.core.windows.net/', variables('name').sa.containerName,'/',variables('name').disk.os,'.vhd')]"
-            },
-            "caching": "ReadWrite",
+            "name": "[variables('name').disk.os]",
+            "caching": "ReadOnly",
             "createOption": "FromImage"
           },
           "dataDisks": [
             {
-              "name": "datadisk1",
+              "name": "[variables('name').disk.data]",
               "diskSizeGB": "100",
               "lun": 0,
-              "vhd": {
-                "uri": "[concat('http://', variables('name').sa.name, '.blob.core.windows.net/' ,variables('name').sa.containerName,'/',variables('name').disk.data,'.vhd')]"
-              },
               "createOption": "Empty"
             }
           ]
@@ -143,8 +137,7 @@
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
-            "enabled": "false",
-            "storageUri": "[concat('http://', variables('name').sa.name, '.blob.core.windows.net')]"
+            "enabled": "false"
           }
         }
       }


### PR DESCRIPTION
The templates have now all been converted to use Managed Disks.

The URL that is required for downloading Automate has been updated in the `setup-ctl.sh` script.