### PR TITLE
Linux VMs configured for 100GB OS disks

### DIFF
--- a/solutions/nested/virtual-machine/virtual-machine-ubuntu.json
+++ b/solutions/nested/virtual-machine/virtual-machine-ubuntu.json
@@ -171,6 +171,7 @@
           },
           "osDisk": {
             "name": "[variables('name').disk.os]",
+            "diskSizeGB": "100",
             "caching": "ReadOnly",
             "createOption": "FromImage"
           },


### PR DESCRIPTION
Increasing OS disk size for Linux VMs created by these ARM templates will provide additional disk IOPS